### PR TITLE
linux-uclan: Fix build with gcc 10+ host compiler

### DIFF
--- a/recipes-bsp/linux/files/make-yyloc-declaration-extern.patch
+++ b/recipes-bsp/linux/files/make-yyloc-declaration-extern.patch
@@ -1,0 +1,14 @@
+diff --git a/scripts/dtc/dtc-parser.tab.c_shipped b/scripts/dtc/dtc-parser.tab.c_shipped
+index ee1d8c3..a7be9f6 100644
+--- a/scripts/dtc/dtc-parser.tab.c_shipped
++++ b/scripts/dtc/dtc-parser.tab.c_shipped
+@@ -1196,7 +1196,7 @@ int yychar;
+ /* The semantic value of the lookahead symbol.  */
+ YYSTYPE yylval;
+ /* Location data for the lookahead symbol.  */
+-YYLTYPE yylloc
++extern YYLTYPE yylloc
+ # if defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL
+   = { 1, 1, 1, 1 }
+ # endif
+ 

--- a/recipes-bsp/linux/linux-hd_4.10.12.bb
+++ b/recipes-bsp/linux/linux-hd_4.10.12.bb
@@ -35,6 +35,7 @@ SRC_URI_append_arm = " \
 	file://blacklist_mmc0.patch \
 	file://export_pmpoweroffprepare.patch \
 	file://enable_hauppauge_solohd.patch \
+	file://make-yyloc-declaration-extern.patch \
 "
 
 S = "${WORKDIR}/linux-${PV}"

--- a/recipes-bsp/linux/linux-hd_4.4.35.bb
+++ b/recipes-bsp/linux/linux-hd_4.4.35.bb
@@ -27,6 +27,7 @@ SRC_URI = "http://downloads.mutant-digital.net/linux-${PV}-${SRCDATE}-${ARCH}.ta
 	file://0003-dont-mark-register-as-const.patch \
 	file://0004-linux-fix-buffer-size-warning-error.patch \
 	file://Backport_minimal_compiler_attributes_h_to_support_GCC_9.patch \
+	file://make-yyloc-declaration-extern.patch \
 "
 
 # By default, kernel.bbclass modifies package names to allow multiple kernels


### PR DESCRIPTION
/home/hains/openpli-oe-core/build/tmp/hosttools/ld: scripts/dtc/dtc-parser.tab.o:(.bss+0x10):
 multiple definition of `yylloc'; scripts/dtc/dtc-lexer.lex.o:(.bss+0x0): first defined here
| collect2: error: ld returned 1 exit status